### PR TITLE
Cambios para usar python:alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,10 @@
-FROM debian:jessie-slim
+FROM python:alpine
 MAINTAINER  Fábrica de Software Libre <libregob@fslibre.com>
 
-# Dockerfile base desarrollado por el usuario arkhan del sitio notabug.org
-RUN apt-get update && \
-    apt-get install -y python-dev curl gcc && \
-    rm -rf /var/lib/apt/lists/* && \
-    curl -sL https://bootstrap.pypa.io/get-pip.py >> /tmp/get-pip.py && \
-    python /tmp/get-pip.py && \
-    rm -rf /tmp/get-pip.py
+# Basado en yajo/wdb-server
+RUN apk add --no-cache --virtual .build-deps build-base python-dev linux-headers \
+    && pip install wdb.server \
+    && apk del .build-deps
 
-# WDB debugger
-RUN /usr/local/bin/pip install --no-cache-dir wdb.server
-
+CMD ["wdb.server.py", "--log_to_stderr"]
 EXPOSE 1984 19840
-
-CMD wdb.server.py --log_to_stderr
-


### PR DESCRIPTION
Basado en la imagen de https://bitbucket.org/yajo/docker-wdb-server/src/9cecb1cfaf9b785d5c86a67942310c3c7b87639a/Dockerfile?at=default&fileviewer=file-view-default